### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ result.invalidRule // StartsWith("J")
 
 # Installation
 
-Package is available on [Cocoapods](https://cocoapods.org/pods/Honour). See the ["Using CocoaPods" guide for more information](https://guides.cocoapods.org/using/using-cocoapods.html).
+Package is available on [CocoaPods](https://cocoapods.org/pods/Honour). See the ["Using CocoaPods" guide for more information](https://guides.cocoapods.org/using/using-cocoapods.html).
 
 ```ruby
 use_frameworks!


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
